### PR TITLE
Correct RGBTHRESH keyword check and documentation

### DIFF
--- a/IDL/cocoplot.pro
+++ b/IDL/cocoplot.pro
@@ -22,7 +22,7 @@ FUNCTION COCOPLOT, coco_datacube, filter=filter, rgbthresh=rgbthresh, threshmeth
 ; KEYWORD PARAMETERS:
 ;   filter:         Filter of dimensions [nspect_points, 3] specifying
 ;                   values used to color collpase the datacube. 
-;   rgbthresh:      Flag to apply saturation thresholding. Defaults to not set.
+;   rgbthresh:      Saturation thresholding values. Defaults to min-max.
 ;   threshmethod:   Scalar string specifying the Saturation thresholding method.
 ;                   Can be 'fraction', 'numeric' or 'percentile'. Defaults to not set.
 ;   quiet:          Do not pop-up display image. Defaults to not set.

--- a/IDL/cocorgb.pro
+++ b/IDL/cocorgb.pro
@@ -20,7 +20,7 @@ FUNCTION COCORGB, coco_datacube_in, filter, rgbthresh=rgbthresh, threshmethod=th
 ;         filter:         Filter of dimensions [nspect_points, 3]. 
 ;
 ; KEYWORD PARAMETERS:
-;	  rgbthresh:      Flag to apply saturation thresholding. Defaults to not set.
+;	  rgbthresh:      Saturation thresholding values. Defaults to min-max.
 ;         threshmethod:   Scalar string specifying the Saturation thresholding method.
 ;                         Can be 'fraction', 'numeric' or 'percentile'. Defaults to not set.
 ;
@@ -40,7 +40,7 @@ FUNCTION COCORGB, coco_datacube_in, filter, rgbthresh=rgbthresh, threshmethod=th
 coco_datacube=coco_datacube_in
 dims=size(coco_datacube)
 ; Thresholding: saturation at max and zero at min values
-IF keyword_set(rgbthresh) THEN BEGIN
+IF (N_ELEMENTS(rgbthresh) GT 0) THEN BEGIN
    CASE threshmethod OF
    'fraction': BEGIN
       datamin=min(coco_datacube, /NAN)

--- a/IDL/cocovideo.pro
+++ b/IDL/cocovideo.pro
@@ -24,7 +24,7 @@ PRO COCOVIDEO, coco_datacube, filter, fps, name, filepath=filepath, startstop=st
 ;   filepath:       Output filepath prefixed to the "name" variable.
 ;   startstop:      Start and stop indices for time dimension. Defaults to
 ;                   [0,nt-1].
-;   rgbthresh:      Flag to apply saturation thresholding. Defaults to not set.
+;   rgbthresh:      Saturation thresholding values. Defaults to min-max.
 ;   threshmethod:   Scalar string specifying the Saturation thresholding method.
 ;                   Can be 'fraction', 'numeric' or 'percentile'. Defaults to not set.
 ;   loud:           Display the video. Defaults to not set.


### PR DESCRIPTION
RGBTHRESH was previously stated to be a boolean keyword, but in its usage in
COCORGB() it may take on values other than 0 and 1, and also be a 2-element
array. Changed the documentation to reflect this and corrected the check for
setting of the keyword in COCORGB().