### PR TITLE
Implement COCOFILTER_DEFAULTS function

### DIFF
--- a/IDL/cocofilter.pro
+++ b/IDL/cocofilter.pro
@@ -67,18 +67,16 @@ FUNCTION COCOFILTER, Array, FILTERTYPE=filtertype, R=r, G=g, B=b
   ENDIF
 
   ; Process inputs
-  nArray=N_ELEMENTS(array)
-  IF (nArray GT 1) THEN $
-    array_filt=Array $
-  ELSE BEGIN
-    array_filt=INDGEN(Array)
-    nArray=N_ELEMENTS(array_filt)
-  ENDELSE
+  nArray = N_ELEMENTS(array)
+  IF (nArray EQ 1) THEN BEGIN
+    Array = INDGEN(Array)
+    nArray = N_ELEMENTS(Array)
+  ENDIF
   IF (N_ELEMENTS(filtertype) NE 1) THEN filtertype = 'normal'
 
   ; Get filter defaults and create filters
   default = COCOFILTER_DEFAULTS(Array, FILTERTYPE=filtertype)
-  filter = DBLARR(nArray,3)   ; Output filter definition, overridden for 'normal'
+  filter = DBLARR(nArray,3)   ; Output filter definition; gets overridden for 'normal'
   IF ( ((N_ELEMENTS(R) NE 2) AND (filtertype NE 'single')) OR $
         (N_ELEMENTS(R) LT 1)) THEN r = default.r
   IF ( ((N_ELEMENTS(G) NE 2) AND (filtertype NE 'single')) OR $
@@ -102,9 +100,9 @@ FUNCTION COCOFILTER, Array, FILTERTYPE=filtertype, R=r, G=g, B=b
                   FOR i_filt2=filt_bits[i_filt,0],filt_bits[i_filt,1] DO filter[i_filt2,i_filt]=filt_int[i_filt]
                 ENDFOR
               END
-    'normal': filter = [ [COCOFILTNORM(array_filt, r[0], r[1])], $
-                         [COCOFILTNORM(array_filt, g[0], g[1])], $
-                         [COCOFILTNORM(array_filt, b[0], b[1])] ]
+    'normal': filter = [ [COCOFILTNORM(Array, r[0], r[1])], $
+                         [COCOFILTNORM(Array, g[0], g[1])], $
+                         [COCOFILTNORM(Array, b[0], b[1])] ]
 
   ENDCASE
   RETURN, filter

--- a/IDL/cocofilter.pro
+++ b/IDL/cocofilter.pro
@@ -81,18 +81,18 @@ FUNCTION COCOFILTER, Array, FILTERTYPE=filtertype, R=r, G=g, B=b
 
   CASE filtertype OF
     'single': BEGIN
-                filter=MAKE_ARRAY(nArray,3,/DOUBLE,VALUE=0)
+                filter = DBLARR(nArray,3)
                 IF (N_ELEMENTS(r) EQ 1) THEN filter[r,0]=1D ELSE filter[default.r,0] =1D
                 IF (N_ELEMENTS(g) EQ 1) THEN filter[g,1]=1D ELSE filter[default.g,1] =1D
                 IF (N_ELEMENTS(b) EQ 1) THEN filter[b,2]=1D ELSE filter[default.b,2] =1D
               END
     'band':   BEGIN
-                filter=MAKE_ARRAY(nArray,3,/DOUBLE,VALUE=0)
-                filt_bits=MAKE_ARRAY(3,2,/DOUBLE)
+                filter = DBLARR(nArray,3)
+                filt_bits = DBLARR(3,2)
                 IF (N_ELEMENTS(r) EQ 2) THEN filt_bits[0,*]=r ELSE filt_bits[0,*]=default.r
                 IF (N_ELEMENTS(g) EQ 2) THEN filt_bits[1,*]=g ELSE filt_bits[1,*]=default.g
                 IF (N_ELEMENTS(b) EQ 2) THEN filt_bits[2,*]=b ELSE filt_bits[2,*]=default.b
-                filt_int=1D/double(filt_bits[*,1]-filt_bits[*,0]+1)
+                filt_int=1D/DOUBLE(filt_bits[*,1]-filt_bits[*,0]+1)
                 FOR i_filt=0,2 DO BEGIN
                   FOR i_filt2=filt_bits[i_filt,0],filt_bits[i_filt,1] DO filter[i_filt2,i_filt]=filt_int[i_filt]
                 ENDFOR

--- a/IDL/cocofilter.pro
+++ b/IDL/cocofilter.pro
@@ -82,17 +82,16 @@ FUNCTION COCOFILTER, Array, FILTERTYPE=filtertype, R=r, G=g, B=b
   CASE filtertype OF
     'single': BEGIN
                 filter=MAKE_ARRAY(nArray,3,/DOUBLE,VALUE=0)
-                IF (N_ELEMENTS(r) EQ 1) THEN filter[r,0]=1D ELSE filter[nArray-1,0] =1D
-                IF (N_ELEMENTS(g) EQ 1) THEN filter[g,1]=1D ELSE filter[ROUND((nArray-1)/2),1] =1D
-                IF (N_ELEMENTS(b) EQ 1) THEN filter[b,2]=1D ELSE filter[0,2] =1D
+                IF (N_ELEMENTS(r) EQ 1) THEN filter[r,0]=1D ELSE filter[default.r,0] =1D
+                IF (N_ELEMENTS(g) EQ 1) THEN filter[g,1]=1D ELSE filter[default.g,1] =1D
+                IF (N_ELEMENTS(b) EQ 1) THEN filter[b,2]=1D ELSE filter[default.b,2] =1D
               END
     'band':   BEGIN
                 filter=MAKE_ARRAY(nArray,3,/DOUBLE,VALUE=0)
                 filt_bits=MAKE_ARRAY(3,2,/DOUBLE)
-                nl=DOUBLE(nArray-1)
-                IF (N_ELEMENTS(r) EQ 2) THEN filt_bits[0,*]=r ELSE filt_bits[0,*]=[CEIL((2D*(nl))/3D),nArray-1]
-                IF (N_ELEMENTS(g) EQ 2) THEN filt_bits[1,*]=g ELSE filt_bits[1,*]=[CEIL((nl)/3D),FLOOR((2D*(nl))/3D)]
-                IF (N_ELEMENTS(b) EQ 2) THEN filt_bits[2,*]=b ELSE filt_bits[2,*]=[0,FLOOR((nl)/3D)]
+                IF (N_ELEMENTS(r) EQ 2) THEN filt_bits[0,*]=r ELSE filt_bits[0,*]=default.r
+                IF (N_ELEMENTS(g) EQ 2) THEN filt_bits[1,*]=g ELSE filt_bits[1,*]=default.g
+                IF (N_ELEMENTS(b) EQ 2) THEN filt_bits[2,*]=b ELSE filt_bits[2,*]=default.b
                 filt_int=1D/double(filt_bits[*,1]-filt_bits[*,0]+1)
                 FOR i_filt=0,2 DO BEGIN
                   FOR i_filt2=filt_bits[i_filt,0],filt_bits[i_filt,1] DO filter[i_filt2,i_filt]=filt_int[i_filt]
@@ -100,32 +99,13 @@ FUNCTION COCOFILTER, Array, FILTERTYPE=filtertype, R=r, G=g, B=b
               END
     'normal': BEGIN
                 ; normal distribution "eyelike" filters"
-                array_filt = DOUBLE(array_filt)
-                IF (N_ELEMENTS(b) EQ 2) THEN BEGIN
-                  prof_sigma=DOUBLE(b[1])
-                  prof_mean=DOUBLE(b[0])
-                ENDIF ELSE BEGIN
-                  prof_sigma=(array_filt[nArray-1]-array_filt[0])/(2.0D*1.96D)
-                  prof_mean=array_filt[0]
-                ENDELSE
-                filter_b=COCOFILTNORM(array_filt, prof_mean, prof_sigma)
-                IF (N_ELEMENTS(g) EQ 2) THEN BEGIN
-                  prof_sigma=DOUBLE(g[1])
-                  prof_mean=DOUBLE(g[0])
-                ENDIF ELSE BEGIN
-                  prof_mean=(array_filt[nArray-1]+array_filt[0])/2.0D
-                  prof_sigma=(array_filt[nArray-1]-array_filt[0])/(2.0D*1.96D)
-                ENDELSE
-                filter_g=COCOFILTNORM(array_filt, prof_mean, prof_sigma)
-                IF (N_ELEMENTS(r) EQ 2) THEN BEGIN 
-                  prof_sigma=DOUBLE(r[1])
-                  prof_mean=DOUBLE(r[0])
-                ENDIF ELSE BEGIN
-                  prof_mean=array_filt[nArray-1]
-                  prof_sigma=(array_filt[nArray-1]-array_filt[0])/(2.0D*1.96D)
-                ENDELSE
-                filter_r=COCOFILTNORM(array_filt, prof_mean, prof_sigma)
-                filter=[[filter_r], [filter_g], [filter_b]]
+                IF (N_ELEMENTS(r) NE 2) THEN r = default.r
+                IF (N_ELEMENTS(g) NE 2) THEN g = default.g
+                IF (N_ELEMENTS(b) NE 2) THEN b = default.b
+                filter = [ [COCOFILTNORM(array_filt, r[0], r[1])], $
+                           [COCOFILTNORM(array_filt, g[0], g[1])], $
+                           [COCOFILTNORM(array_filt, b[0], b[1])] ]
+
               END
   ENDCASE
   RETURN, filter

--- a/IDL/cocofilter.pro
+++ b/IDL/cocofilter.pro
@@ -66,6 +66,7 @@ FUNCTION COCOFILTER, Array, FILTERTYPE=filtertype, R=r, G=g, B=b
     RETURN, !NULL
   ENDIF
 
+  ; Process inputs
   nArray=N_ELEMENTS(array)
   IF (nArray GT 1) THEN $
     array_filt=Array $
@@ -74,6 +75,10 @@ FUNCTION COCOFILTER, Array, FILTERTYPE=filtertype, R=r, G=g, B=b
     nArray=N_ELEMENTS(array_filt)
   ENDELSE
   IF (N_ELEMENTS(filtertype) NE 1) THEN filtertype = 'normal'
+
+  ; Get filter defaults and create filters
+  default = COCOFILTER_DEFAULTS(Array, FILTERTYPE=filtertype)
+
   CASE filtertype OF
     'single': BEGIN
                 filter=MAKE_ARRAY(nArray,3,/DOUBLE,VALUE=0)

--- a/IDL/cocofilter.pro
+++ b/IDL/cocofilter.pro
@@ -78,20 +78,23 @@ FUNCTION COCOFILTER, Array, FILTERTYPE=filtertype, R=r, G=g, B=b
 
   ; Get filter defaults and create filters
   default = COCOFILTER_DEFAULTS(Array, FILTERTYPE=filtertype)
+  filter = DBLARR(nArray,3)   ; Output filter definition, overridden for 'normal'
 
   CASE filtertype OF
     'single': BEGIN
-                filter = DBLARR(nArray,3)
-                IF (N_ELEMENTS(r) EQ 1) THEN filter[r,0]=1D ELSE filter[default.r,0] =1D
-                IF (N_ELEMENTS(g) EQ 1) THEN filter[g,1]=1D ELSE filter[default.g,1] =1D
-                IF (N_ELEMENTS(b) EQ 1) THEN filter[b,2]=1D ELSE filter[default.b,2] =1D
+                IF (N_ELEMENTS(r) LT 1) THEN r = default.r
+                IF (N_ELEMENTS(g) LT 1) THEN g = default.g
+                IF (N_ELEMENTS(b) LT 1) THEN b = default.b
+                filter[r,0] = 1D  & filter[g,1] = 1D  & filter[b,2] = 1D
+
               END
     'band':   BEGIN
-                filter = DBLARR(nArray,3)
                 filt_bits = DBLARR(3,2)
-                IF (N_ELEMENTS(r) EQ 2) THEN filt_bits[0,*]=r ELSE filt_bits[0,*]=default.r
-                IF (N_ELEMENTS(g) EQ 2) THEN filt_bits[1,*]=g ELSE filt_bits[1,*]=default.g
-                IF (N_ELEMENTS(b) EQ 2) THEN filt_bits[2,*]=b ELSE filt_bits[2,*]=default.b
+                IF (N_ELEMENTS(r) NE 2) THEN r = default.r
+                IF (N_ELEMENTS(g) NE 2) THEN g = default.g
+                IF (N_ELEMENTS(b) NE 2) THEN b = default.b
+                filt_bits[0,*] = r  & filt_bits[1,*] = g  & filt_bits[2,*] = b 
+
                 filt_int=1D/DOUBLE(filt_bits[*,1]-filt_bits[*,0]+1)
                 FOR i_filt=0,2 DO BEGIN
                   FOR i_filt2=filt_bits[i_filt,0],filt_bits[i_filt,1] DO filter[i_filt2,i_filt]=filt_int[i_filt]

--- a/IDL/cocofilter.pro
+++ b/IDL/cocofilter.pro
@@ -79,37 +79,33 @@ FUNCTION COCOFILTER, Array, FILTERTYPE=filtertype, R=r, G=g, B=b
   ; Get filter defaults and create filters
   default = COCOFILTER_DEFAULTS(Array, FILTERTYPE=filtertype)
   filter = DBLARR(nArray,3)   ; Output filter definition, overridden for 'normal'
+  IF ( ((N_ELEMENTS(R) NE 2) AND (filtertype NE 'single')) OR $
+        (N_ELEMENTS(R) LT 1)) THEN r = default.r
+  IF ( ((N_ELEMENTS(G) NE 2) AND (filtertype NE 'single')) OR $
+        (N_ELEMENTS(G) LT 1)) THEN g = default.g
+  IF ( ((N_ELEMENTS(B) NE 2) AND (filtertype NE 'single')) OR $
+        (N_ELEMENTS(B) LT 1)) THEN b = default.b
 
   CASE filtertype OF
     'single': BEGIN
-                IF (N_ELEMENTS(r) LT 1) THEN r = default.r
-                IF (N_ELEMENTS(g) LT 1) THEN g = default.g
-                IF (N_ELEMENTS(b) LT 1) THEN b = default.b
-                filter[r,0] = 1D  & filter[g,1] = 1D  & filter[b,2] = 1D
-
+                filter[r,0] = 1D  
+                filter[g,1] = 1D  
+                filter[b,2] = 1D
               END
     'band':   BEGIN
                 filt_bits = DBLARR(3,2)
-                IF (N_ELEMENTS(r) NE 2) THEN r = default.r
-                IF (N_ELEMENTS(g) NE 2) THEN g = default.g
-                IF (N_ELEMENTS(b) NE 2) THEN b = default.b
-                filt_bits[0,*] = r  & filt_bits[1,*] = g  & filt_bits[2,*] = b 
-
+                filt_bits[0,*] = r  
+                filt_bits[1,*] = g  
+                filt_bits[2,*] = b 
                 filt_int=1D/DOUBLE(filt_bits[*,1]-filt_bits[*,0]+1)
                 FOR i_filt=0,2 DO BEGIN
                   FOR i_filt2=filt_bits[i_filt,0],filt_bits[i_filt,1] DO filter[i_filt2,i_filt]=filt_int[i_filt]
                 ENDFOR
               END
-    'normal': BEGIN
-                ; normal distribution "eyelike" filters"
-                IF (N_ELEMENTS(r) NE 2) THEN r = default.r
-                IF (N_ELEMENTS(g) NE 2) THEN g = default.g
-                IF (N_ELEMENTS(b) NE 2) THEN b = default.b
-                filter = [ [COCOFILTNORM(array_filt, r[0], r[1])], $
-                           [COCOFILTNORM(array_filt, g[0], g[1])], $
-                           [COCOFILTNORM(array_filt, b[0], b[1])] ]
+    'normal': filter = [ [COCOFILTNORM(array_filt, r[0], r[1])], $
+                         [COCOFILTNORM(array_filt, g[0], g[1])], $
+                         [COCOFILTNORM(array_filt, b[0], b[1])] ]
 
-              END
   ENDCASE
   RETURN, filter
 END

--- a/IDL/cocofilter_defaults.pro
+++ b/IDL/cocofilter_defaults.pro
@@ -1,0 +1,86 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+FUNCTION COCOFILTER_DEFAULTS, Array, FILTERTYPE=filtertype
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;+
+; NAME:
+;   COCOFILTER_DEFAULTS
+;
+; PURPOSE:
+;   Return COCOPLOT filters defaults.
+;
+; CATEGORY:
+;   COCOPLOT core
+;
+; CALLING SEQUENCE:
+;   Result = COCOFILTER_DEFAULTS(Array)
+;
+; INPUTS:
+;   Array:  1D-array (integer, float or byte) with spectral or time values.
+;
+; KEYWORD PARAMETERS:
+;	  FILTERTYPE:	  Scalar string specifying the type of filter. One of three
+;                 values is accepted:
+;                 'single'  : Single points.
+;                             If set, return structure contains the
+;                             indices in Array to use for each filter.
+;                 'band'    : Bands of points.
+;                             If set, return structure contains 2-element
+;                             arrays with the lower and upper indices in Array for
+;                             each filter.
+;                 'normal'  : Normal distribution filters, like the cones of the eye
+;                             If set, return structure contains 2-element
+;                             arrays with the means (first element) and standard
+;                             deviation (second element) of the normal 
+;                             distribution functions used in the rgb filters.
+;                 Defaults to 'normal'.
+;
+; OUTPUTS:
+;   Structure with filter default values for R, G and B to be used by
+;   COCOFILTER().
+;
+; EXAMPLE:
+;   defaults = COCOFILTER_DEFAULTS(FINDGEN(101)-50, filtertype='band')
+;   HELP, defaults, /STRUCT
+;
+; MODIFICATION HISTORY:
+;   Written by: Malcolm Druett & Gregal Vissers, August 2019
+;-
+
+  IF (N_PARAMS() LT 1) THEN BEGIN
+    MESSAGE, 'Syntax: Result = COCOFILTER_DEFAULTS(Array '+$
+      '[, FILTERTYPE=filtertype])', /INFO
+    RETURN, !NULL
+  ENDIF
+
+  ; Process inputs
+  nArray = N_ELEMENTS(Array)
+  IF (N_ELEMENTS(filtertype) NE 1) THEN filtertype = 'normal'
+
+  ; Get defaults
+  CASE filtertype OF
+    'single': BEGIN
+                r = nArray-1
+                g = ROUND((nArray-1)/2.)
+                b = 0
+              END
+    'band':   BEGIN
+                r = [CEIL((2D*(nArray-1))/3D),nArray-1]
+                g = [CEIL((nArray-1)/3D),FLOOR((2D*(nArray-1))/3D)]
+                b = [0,FLOOR((nArray-1)/3D)]
+              END
+    'normal': BEGIN
+                stdev = (Array[nArray-1]-Array[0])/(2.D*1.96D)
+                b = [Array[0], stdev]
+                g = [(Array[nArray-1]+Array[0])/2.0D, stdev]
+                r = [Array[nArray-1], stdev]
+              END
+    ELSE:     BEGIN
+                MESSAGE, "ERROR: Filtertype not recognized. Must be one "+$
+                  "of 'single', 'band' or 'normal'.", /INFO
+                RETURN, !NULL
+              END
+  ENDCASE
+
+  RETURN, {r:r, g:g, b:b}
+
+END

--- a/IDL/cocorgb.pro
+++ b/IDL/cocorgb.pro
@@ -46,15 +46,15 @@ FUNCTION COCORGB, coco_datacube_in, filter, RGBTHRESH=rgbthresh, THRESHMETHOD=th
   dims=SIZE(coco_datacube)
   ; Thresholding: saturation at max and zero at min values
   IF (N_ELEMENTS(rgbthresh) GT 0) THEN BEGIN
+    datamin = MIN(coco_datacube, /NAN, MAX=datamax)
     CASE threshmethod OF
-      'fraction': BEGIN
-                    datamin=MIN(coco_datacube, /NAN)
-                    datamax=MAX(coco_datacube, /NAN)
-                    datarange=datamin+rgbthresh*(datamax-datamin)
-                  END
+      'fraction': datarange=datamin+rgbthresh*(datamax-datamin)
       'numeric':  datarange=rgbthresh
       'percentile': datarange=cgPercentiles(coco_datacube, PERCENTILES=rgbthresh)
-      ELSE: MESSAGE, "threshmethod not recognised. Should be 'fraction', 'numeric' or 'percentile'.", /INFO
+      ELSE: BEGIN
+              MESSAGE, "threshmethod not recognised. Should be 'fraction', 'numeric' or 'percentile'.", /INFO
+              datarange = [datamin, datamax]
+            END
     ENDCASE
     IF (MIN(FINITE(datarange)) EQ 0) THEN MESSAGE, "NAN or INFINTE data detected in requested range.", /INFO
     iw=WHERE(coco_datacube GT datarange[1], count)


### PR DESCRIPTION
Function added to return filter parameter defaults to be used in `COCOFILTER()`; modified the latter to read those defaults and simplified the setting of the filter (e.g. taken common elements outside of `CASE`-statement).

Also added a failsafe to `COCORGB()` for undefined `THRESHMETHOD`